### PR TITLE
Make links visible

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -77,3 +77,7 @@
   font-size: 1.3rem;
   font-weight: 300;
 }
+
+p a {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Links in the documentation had no visual cue that they are different from text. The only visual cue happened on mouse-over, because then the links had a `text-decoration: underline`. We fix that by making the underline appear all the time.