### PR TITLE
adding support for prevent_site_translation parameter

### DIFF
--- a/docs/general/guides/deployment/assets/config.auth.yml
+++ b/docs/general/guides/deployment/assets/config.auth.yml
@@ -569,6 +569,9 @@ config:
       - gl
       - ca
 
+    # Prevents site translation using the translation=no html attribute
+    prevent_site_translation: false
+
     defaultRoute: /admin/login
 
     # Minimum loading time (milliseconds)

--- a/docs/general/guides/deployment/assets/config.master.yml
+++ b/docs/general/guides/deployment/assets/config.master.yml
@@ -570,6 +570,9 @@ config:
       - gl
       - ca
 
+    # Prevents site translation using the translation=no html attribute
+    prevent_site_translation: false
+
     defaultRoute: /admin/login
 
     # Minimum loading time (milliseconds)


### PR DESCRIPTION
## Problem description

In some cases, the web browser automatically translates the frontend web sites when it shouldn't. EPI has reported this happening in a case in which the whole website is already in english, but the browser detects the german article `die` as an english word and translate it to the english translation of the word `die`. Not good.

## Proposed Solution

Add to `config.yml` a parameter `config.sequent_ui.prevent_site_translation` that is `false` by default, but when enabled it sets the `translate="no"` attribute to the `<html>` element . [`translate`is an official HTML5 attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate) that indicates that the content of this element should not be translated.

## Rationale

Adding the `translate="no"` attribute should prevent the browser from translating what it shouldn't. Note that, we are already indicating the language of the content in the HTML element, so it should not be translating from that language. And if the text language is for example "german" and the user wants a translation to "arabic", we would be preventing that from happening. For that reason, this should not be enabled by default. But in any specific deployment, it can be set.