### PR TITLE
alternative auth methods: switch back to smartlink tab fails

### DIFF
--- a/docs/general/guides/messaging-voters/messaging-voters.md
+++ b/docs/general/guides/messaging-voters/messaging-voters.md
@@ -42,13 +42,17 @@ both the email/sms of the voter and the voter authentication code. If no other
 in the `__URL2__` URLs allows voters to authenticate without having to fill out 
 any web form. It's easier, but also more risky because anyone with this link 
 could use it to authenticate.
+- `__URL_<alt-auth-method-id>__` and `__URL2_<alt-auth-method-id>__` if you are using [`alternative_auth_methods`](../../reference/election-creation-json/#census-alternative_auth_methods), with the `alt-auth-method-id`
+[sluggified](https://docs.djangoproject.com/en/3.1/ref/utils/#django.utils.text.slugify).
 - `__CODE__`: This is the authentication code. By default each time the
 authentication codes are sent to a voter, a new code is generated and any old
 codes are disabled. Alternatively, the code might be fixed / static if the
 [`fixed-code` is set to `true`](../../reference/election-creation-json#census-config-fixed-code).
 - `__OTL__`: Includes a One Time Link (OTL). This OTL accesses to an
 authentication process that, once authenticated, shows the authentication code
-to voters.
+to voters. Only works if
+[`support_otl_enabled`](../../reference/election-creation-json#support_otl_enabled)
+is enabled.
 - `__<extra_field>__`: Each voter has some voter related information 
 associated to it. You can use those extra fields by the 
 [sluggified](https://docs.djangoproject.com/en/3.1/ref/utils/#django.utils.text.slugify) 

--- a/docs/general/reference/election-creation-json.md
+++ b/docs/general/reference/election-creation-json.md
@@ -2691,9 +2691,15 @@ both the email/sms of the voter and the voter authentication code. If no other
 in the `__URL2__` URLs allows voters to authenticate without having to fill out 
 any web form. It's easier, but also more risky because anyone with this link 
 could use it to authenticate.
+- `__URL_<alt-auth-method-id>__` and `__URL2_<alt-auth-method-id>__` if you are using [`alternative_auth_methods`](#census-alternative_auth_methods), with the `alt-auth-method-id`
+[sluggified](https://docs.djangoproject.com/en/3.1/ref/utils/#django.utils.text.slugify).
 - `__CODE__`: This is the authentication code. Each time the authentication 
 codes are sent to a voter, a new code is generated and any old codes are 
 disabled.
+- `__OTL__`: Includes a One Time Link (OTL). This OTL accesses to an
+authentication process that, once authenticated, shows the authentication code
+to voters. Only works if [`support_otl_enabled`](#support_otl_enabled) is
+enabled.
 - `__<extra_field>__`: Each voter has some voter related information 
 associated to it. You can use those extra fields by the 
 [sluggified](https://docs.djangoproject.com/en/3.1/ref/utils/#django.utils.text.slugify) 


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/222

Adding missing documentation of how to send alt-auth to voters