### PR TITLE
🐞 Documentation: OIDC config is using wrongly named `private_config` vs `private_info` field

### DIFF
--- a/docs/general/guides/openid-auth/assets/oidc-election.json.yaml
+++ b/docs/general/guides/openid-auth/assets/oidc-election.json.yaml
@@ -44,7 +44,7 @@
             "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
             "logout_uri": "https://accounts.google.com/o/oauth2/v2/auth_logout"
           },
-          "private_config": {
+          "private_info": {
             "client_secret": "<CLIENT_SECRET>"
           }
         }


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/659